### PR TITLE
Add Faraday dependency

### DIFF
--- a/ldp_testsuite_wrapper.gemspec
+++ b/ldp_testsuite_wrapper.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rubyzip"
+  spec.add_dependency "faraday"
   spec.add_dependency "ruby-progressbar"
 
   spec.add_development_dependency "bundler", "~> 1.7"

--- a/lib/ldp_testsuite_wrapper/rspec.rb
+++ b/lib/ldp_testsuite_wrapper/rspec.rb
@@ -1,4 +1,5 @@
 require 'nokogiri'
+require 'faraday'
 
 RSpec.shared_examples 'ldp test suite' do
   let(:report_path) { File.expand_path('test-output/testng-results.xml') }


### PR DESCRIPTION
Faraday is required by `/rspec.rb`. This saves Derby and RDF-LDP from the need to add the dependency themselves.
